### PR TITLE
hotfix fix Campaign response

### DIFF
--- a/lib/PartnerAPI.php
+++ b/lib/PartnerAPI.php
@@ -10,7 +10,7 @@ class PartnerAPI
     private $clientSecret;
     private $apiBase;
 
-    const VERSION = '0.4.1';
+    const VERSION = '0.4.3';
 
     private $config = array();
 

--- a/lib/Response/Campaign.php
+++ b/lib/Response/Campaign.php
@@ -16,7 +16,7 @@ class Campaign extends Base
      */
     public $name;
     /**
-     * @var User[]
+     * @var User[]|null
      */
     public $applicableShops;
     /**

--- a/lib/Response/Campaign.php
+++ b/lib/Response/Campaign.php
@@ -70,8 +70,11 @@ class Campaign extends Base
 
     protected function normalize($timezone)
     {
-        $this->startsAt->setTimezone(new DateTimeZone($timezone));
-        $this->endsAt->setTimezone(new DateTimeZone($timezone));
-        $this->pointExpiresAt->setTimezone(new DateTimeZone($timezone));
+      $tz = new DateTimeZone($timezone);
+      $this->startsAt->setTimezone($tz);
+      $this->endsAt->setTimezone($tz);
+      if (isset($this->pointExpiresAt)){
+        $this->pointExpiresAt->setTimezone($tz);
+      }
     }
 }


### PR DESCRIPTION
おそらく生成コードのミスで、nullableなプロパティでnullのときにDateTimeのタイムゾーンを指定しようとしてエラーになっているようだった。
恒久対応としてはpokepay-sdk-generatorの修正だが、一時対応として手動でレスポンスクラスを書き換える