### PR TITLE
v0.4.7 Fix syntax error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ composer.lock
 
 config.ini
 config.test.ini
+
+.phpunit.result.cache

--- a/lib/Response/Campaign.php
+++ b/lib/Response/Campaign.php
@@ -78,7 +78,7 @@ class Campaign extends Base
         $this->startsAt->setTimezone($tz);
         $this->endsAt->setTimezone($tz);
         if (isset($this->pointExpiresAt)){
-            $this->~A->setTimezone($tz);
+            $this->pointExpiresAt->setTimezone($tz);
         }
     }
 }

--- a/lib/Response/Cashtray.php
+++ b/lib/Response/Cashtray.php
@@ -41,7 +41,7 @@ class Cashtray extends Base
         $tz = new DateTimeZone($timezone);
         $this->expiresAt->setTimezone($tz);
         if (isset($this->canceledAt)){
-            $this->~A->setTimezone($tz);
+            $this->canceledAt->setTimezone($tz);
         }
     }
 }

--- a/lib/Response/CashtrayWithResult.php
+++ b/lib/Response/CashtrayWithResult.php
@@ -49,7 +49,7 @@ class CashtrayWithResult extends Base
         $tz = new DateTimeZone($timezone);
         $this->expiresAt->setTimezone($tz);
         if (isset($this->canceledAt)){
-            $this->~A->setTimezone($tz);
+            $this->canceledAt->setTimezone($tz);
         }
     }
 }


### PR DESCRIPTION
pokepay-sdk-generatorのバグでLispのformatの`~A`が残ってしまっていたのを修正