### PR TITLE
v0.4.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "ramsey/uuid": "^3.8",
+        "ramsey/uuid": ">=3.8",
         "netresearch/jsonmapper": "^1.5"
     },
     "autoload": {

--- a/lib/PartnerAPI.php
+++ b/lib/PartnerAPI.php
@@ -10,7 +10,7 @@ class PartnerAPI
     private $clientSecret;
     private $apiBase;
 
-    const VERSION = '0.4.7';
+    const VERSION = '0.4.8';
 
     private $config = array();
 


### PR DESCRIPTION
UUIDライブラリが古いバージョンで固定されておりlaravel9とコンフリクトするらしいので最新のものを許容するように変更